### PR TITLE
Initial work on supporting convex colliders

### DIFF
--- a/examples/load_monkey.rs
+++ b/examples/load_monkey.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_gltf_collider::get_scene_colliders;
+use bevy_gltf_collider::mesh_collider::ColliderMeshType;
 use bevy_rapier3d::prelude::*;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, States, Default)]
@@ -20,13 +21,19 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<GameState>()
         .insert_resource(ClearColor(Color::rgb(0.7, 0.9, 1.0)))
-        .add_plugins((RapierPhysicsPlugin::<NoUserData>::default(), RapierDebugRenderPlugin::default()))
+        .add_plugins((
+            RapierPhysicsPlugin::<NoUserData>::default(),
+            RapierDebugRenderPlugin::default(),
+        ))
         .insert_resource(AmbientLight {
             brightness: 0.5,
             ..default()
         })
         .add_systems(OnEnter(GameState::Loading), (start_assets_loading,))
-        .add_systems(Update, (check_if_loaded,).run_if(in_state(GameState::Loading)))
+        .add_systems(
+            Update,
+            (check_if_loaded,).run_if(in_state(GameState::Loading)),
+        )
         .add_systems(OnEnter(GameState::Loaded), (spawn_monkeys,))
         .run();
 }
@@ -53,8 +60,9 @@ fn check_if_loaded(
     };
 
     // get_scene_colliders should be called only once per scene as it will remove the colliders meshes from it
-    game_assets.monkey_colliders = get_scene_colliders(&mut meshes, &mut scene.world)
-        .expect("Failed to create monkey colliders");
+    game_assets.monkey_colliders =
+        get_scene_colliders(&mut meshes, &mut scene.world, ColliderMeshType::ConvexHull)
+            .expect("Failed to create monkey colliders");
 
     game_state.set(GameState::Loaded);
 }

--- a/examples/load_rocks.rs
+++ b/examples/load_rocks.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_gltf_collider::get_scene_colliders;
+use bevy_gltf_collider::mesh_collider::ColliderMeshType;
 use bevy_rapier3d::prelude::*;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, States, Default)]
@@ -20,13 +21,19 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<GameState>()
         .insert_resource(ClearColor(Color::rgb(0.7, 0.9, 1.0)))
-        .add_plugins((RapierPhysicsPlugin::<NoUserData>::default(), RapierDebugRenderPlugin::default()))
+        .add_plugins((
+            RapierPhysicsPlugin::<NoUserData>::default(),
+            RapierDebugRenderPlugin::default(),
+        ))
         .insert_resource(AmbientLight {
             brightness: 0.5,
             ..default()
         })
         .add_systems(OnEnter(GameState::Loading), (start_assets_loading,))
-        .add_systems(Update, (check_if_loaded,).run_if(in_state(GameState::Loading)))
+        .add_systems(
+            Update,
+            (check_if_loaded,).run_if(in_state(GameState::Loading)),
+        )
         .add_systems(OnEnter(GameState::Loaded), (spawn_rocks,))
         .run();
 }
@@ -53,8 +60,9 @@ fn check_if_loaded(
     };
 
     // get_scene_colliders should be called only once per scene as it will remove the colliders meshes from it
-    game_assets.rock_colliders = get_scene_colliders(&mut meshes, &mut scene.world)
-        .expect("Failed to create rock colliders");
+    game_assets.rock_colliders =
+        get_scene_colliders(&mut meshes, &mut scene.world, ColliderMeshType::ConvexHull)
+            .expect("Failed to create rock colliders");
 
     game_state.set(GameState::Loaded);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::mesh_collider::ColliderMeshType;
 use bevy::{gltf::GltfExtras, prelude::*};
 use bevy_rapier3d::prelude::Collider;
 use extras_collider::{process_extras_collider, ColliderExtrasParsingError};
@@ -28,6 +29,7 @@ pub enum ColliderFromSceneError {
 pub fn get_scene_colliders(
     meshes: &mut Assets<Mesh>,
     world: &mut World,
+    mesh_type: ColliderMeshType,
 ) -> Result<Vec<(Collider, Transform)>, ColliderFromSceneError> {
     let mut result = Vec::new();
 
@@ -47,7 +49,7 @@ pub fn get_scene_colliders(
     let mut entities_to_despawn = Vec::new();
     let mut meshes_q = world.query::<(Entity, &Name, Option<&Children>)>();
     for (entity, entity_name, children) in meshes_q.iter(world) {
-        match process_mesh_collider(entity_name, children, world, meshes) {
+        match process_mesh_collider(entity_name, children, world, meshes, mesh_type) {
             None => {}
             Some(Err(err)) => return Err(ColliderFromSceneError::MeshParsingError(err)),
             Some(Ok(collider)) => {
@@ -69,6 +71,7 @@ pub fn get_scene_colliders(
 pub fn extract_insert_scene_colliders(
     meshes: &mut Assets<Mesh>,
     world: &mut World,
+    mesh_type: ColliderMeshType,
 ) -> Result<Vec<(Collider, Transform, Name)>, ColliderFromSceneError> {
     let mut result = Vec::new();
     let mut entities_to_despawn = Vec::new();
@@ -76,7 +79,7 @@ pub fn extract_insert_scene_colliders(
     let mut names_q = world.query::<(Entity, &Name)>();
 
     for (entity, entity_name, children) in meshes_q.iter(world) {
-        match process_mesh_collider(entity_name, children, world, meshes) {
+        match process_mesh_collider(entity_name, children, world, meshes, mesh_type) {
             None => {}
             Some(Err(err)) => return Err(ColliderFromSceneError::MeshParsingError(err)),
             Some(Ok(collider)) => {

--- a/src/mesh_collider.rs
+++ b/src/mesh_collider.rs
@@ -3,6 +3,7 @@ use bevy::{
     render::mesh::{Indices, VertexAttributeValues},
 };
 use bevy_rapier3d::prelude::Collider;
+use serde::{Deserialize, Serialize};
 
 const COLLIDER_MESH_NAME: &str = "collider";
 
@@ -12,6 +13,8 @@ pub enum ColliderFromMeshError {
     MissingIndices,
     InvalidIndicesCount(usize),
     InvalidPositionsType(&'static str),
+    NonManifold,
+    ConvexHullComputationFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -21,7 +24,39 @@ pub enum ColliderMeshParsingError {
     MeshColliderError(ColliderFromMeshError),
 }
 
-pub fn get_collider_from_mesh(mesh: &Mesh) -> Result<Collider, ColliderFromMeshError> {
+/// How you want your mesh to be treated when creating a collider from it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ColliderMeshType {
+    /// Uses [`Collider::convex_hull`] to take the vertices of the mesh and create a convex
+    /// collider from them. Your mesh doesn't need to be convex for this to work.
+    ///
+    /// See also https://rapier.rs/docs/user_guides/bevy_plugin/colliders#convex-meshes
+    ConvexHull,
+    /// Uses [`Collider::convex_mesh`] create a convex collider from the mesh data. Your mesh must
+    /// be convex and contain no non-manifold geometry for this to work!
+    ///
+    /// Note that I haven't been able to get this to work with any Blender models, including
+    /// simple shapes. Help wanted!
+    ConvexMesh,
+    /// Triangle meshes (in 3D) and polylines (in 2D) can be used to describe the boundary of any
+    /// kind of shape. This is generally useful to describe the fixed environment in games
+    /// (terrains, buildings, etc.) Triangle meshes and polylines are defined by their vertex
+    /// buffer and their index buffer. The winding of the triangles of a triangle mesh does not
+    /// matter. Its topology doesn't matter either (it can have holes, cavities, doesn't need to be
+    /// closed or manifold). It is however strongly recommended to avoid triangles that are long
+    /// and thin because they can result in a lower numerical stability of collision-detection.
+    /// https://rapier.rs/docs/user_guides/bevy_plugin/colliders#triangle-meshes-and-polylines
+    ///
+    /// WARNING: It is discouraged to use a triangle meshes or polylines for colliders attached
+    /// to dynamic rigid-bodies. Because they have no interior, it is easy for another object to
+    /// get stuck into them.
+    TriMesh,
+}
+
+pub fn get_collider_from_mesh(
+    mesh: &Mesh,
+    mesh_type: ColliderMeshType,
+) -> Result<Collider, ColliderFromMeshError> {
     let positions = mesh
         .attribute(Mesh::ATTRIBUTE_POSITION)
         .map_or(Err(ColliderFromMeshError::MissingPositions), Ok)?;
@@ -48,15 +83,20 @@ pub fn get_collider_from_mesh(mesh: &Mesh) -> Result<Collider, ColliderFromMeshE
         return Err(ColliderFromMeshError::InvalidIndicesCount(indices.len()));
     }
 
-    let triple_indices = indices.chunks(3).map(|v| [v[0], v[1], v[2]]).collect();
-    let vertices = positions
+    let triple_indices: Vec<_> = indices.chunks(3).map(|v| [v[0], v[1], v[2]]).collect();
+    let vertices: Vec<_> = positions
         .iter()
         .map(|v| Vec3::new(v[0], v[1], v[2]))
         .collect();
 
-    let collider = Collider::trimesh(vertices, triple_indices);
-
-    Ok(collider)
+    match mesh_type {
+        ColliderMeshType::ConvexHull => {
+            Collider::convex_hull(&vertices).ok_or(ColliderFromMeshError::NonManifold)
+        }
+        ColliderMeshType::ConvexMesh => Collider::convex_mesh(vertices, triple_indices.as_slice())
+            .ok_or(ColliderFromMeshError::NonManifold),
+        ColliderMeshType::TriMesh => Ok(Collider::trimesh(vertices, triple_indices)),
+    }
 }
 
 pub(super) fn process_mesh_collider(
@@ -64,6 +104,7 @@ pub(super) fn process_mesh_collider(
     children: Option<&Children>,
     world: &World,
     meshes: &mut Assets<Mesh>,
+    mesh_type: ColliderMeshType,
 ) -> Option<Result<Collider, ColliderMeshParsingError>> {
     if !node_name.starts_with(COLLIDER_MESH_NAME) {
         return None;
@@ -78,8 +119,7 @@ pub(super) fn process_mesh_collider(
     let collider = children.iter().find_map(|&child| {
         if let Some(mesh) = world.get::<Handle<Mesh>>(child) {
             let mesh = meshes.remove(mesh).unwrap();
-
-            Some(get_collider_from_mesh(&mesh))
+            Some(get_collider_from_mesh(&mesh, mesh_type))
         } else {
             None
         }


### PR DESCRIPTION
Currently this library only supported using Triangle Mesh colliders which are not recommended for using With rigidbodies as it's easy to get stuck inside them as they have no concept of "inside" or "outside". This is some initial work on supporting convex_hull and convex_mesh.

Currently I haven't been able to using convex mesh as Collider::convex_mesh returns none which should only happen when a mesh is non-manifold. Since the meshes I've been using are manifold I assume it's a winding order issue or something, but haven't tracked it down yet. Any help would be appreciated!